### PR TITLE
fix auth bug by redirecting using

### DIFF
--- a/public/js/controllers/signIn.js
+++ b/public/js/controllers/signIn.js
@@ -1,8 +1,8 @@
 angular.module('mean.system')
-  .controller('SignInController', ['$scope', '$cookies', 'Global', '$location',
+  .controller('SignInController', ['$scope', '$cookies', 'Global',
     'AvatarService', '$window', 'userService',
     function SignInController($scope, $cookies, Global,
-      $location, AvatarService, $window, userService) {
+      AvatarService, $window, userService) {
       $scope.global = Global;
       $scope.avatars = [];
       $scope.errorMessage = '';
@@ -16,7 +16,7 @@ angular.module('mean.system')
         userService.signIn(user).then((response) => {
           $cookies.put('token', response.data.token);
           $cookies.putObject('user', response.data.user);
-          $location.path('/');
+          $window.location.href = '/';
         }, (err) => {
           $scope.errorMsg = 'An error occured!!! '.concat(err.error);
         });

--- a/public/js/controllers/signUp.js
+++ b/public/js/controllers/signUp.js
@@ -1,7 +1,7 @@
 /* global angular */
 angular.module('mean.system')
-  .controller('SignUpController', ['$scope', '$cookies', '$location', 'AvatarService', 'userService',
-    function SignUpController ($scope, $cookies, $location, AvatarService, userService) {
+  .controller('SignUpController', ['$scope', '$cookies', '$window', 'AvatarService', 'userService',
+    function SignUpController ($scope, $cookies, $window, AvatarService, userService) {
       $scope.avatars = [];
       $scope.errorMessage = '';
       $scope.hideErrorMessage = 'hidden';
@@ -22,9 +22,9 @@ angular.module('mean.system')
         userService.signUp(data)
           .then((response) => {
             $scope.hideErrorMessage = 'hidden';
-            $cookies.put('token', response.data.jwtToken);
+            $cookies.put('token', response.data.token);
             $cookies.putObject('user', response.data.user);
-            $location.path('/');
+            $window.location.href = '/';
           }, (error) => {
             // Show the error message area and tell the user the error that occured.
             $scope.hideErrorMessage = '';


### PR DESCRIPTION
#### What does this PR do?
Fix a bug with sign in/sign up system of this project. Now, the nav bar gets updated based on the log in status of a user.

#### Description of task to be completed?
Update navigation bar based on the login status of a user.

#### How should this be manually tested?
Clone/Pull this branch and checkout the `bug/144388617/update-navbar-on-signin-signup` branch. Run `npm start` and then try to both sign up and sign in using some random credentials. The navigation bar should now update based on your log in status.

#### Any background context you want to provide?
N/A

#### What are the relevant Pivotal Tracker stories?
144388617 

#### Screenshots
N/A

#### Questions
N/A